### PR TITLE
Fix opening of generated .fit files

### DIFF
--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -1200,7 +1200,7 @@ class PreprocessingInterface:
         img = self.save_image("_og")
         # load og image for autocrop/spcc
         if drizzle:
-            img = os.path.basename(img) + ".fits"
+            img = os.path.basename(img) + ".fit"
         else:
             img = os.path.basename(img)
         self.load_image(image_name=img)
@@ -1221,7 +1221,7 @@ class PreprocessingInterface:
 
             # self.autostretch(do_spcc=do_spcc)
             if drizzle:
-                img = os.path.basename(img) + ".fits"
+                img = os.path.basename(img) + ".fit"
             else:
                 img = os.path.basename(img)
             self.load_image(


### PR DESCRIPTION
Thanks for making this script!  One problem: It crashed when trying to open generated images. It was trying to open a file with a .fits suffix, but the generated file actually had a .fit suffix. Possibly the problem didn't show on Windows because there it was trimming suffixes to three characters?

But this problem occured for me on linux:

13:06:05: Running command: load
13:06:05: Reading FITS: file result.fit, 3 layer(s), 1309x2068 pixels, 32 bits
13:06:05: Loaded image: result
13:06:05: Running command: cd
13:06:05: Setting CWD (Current Working Directory) to '/var/home/kevinh/Pictures/telescope/siril_work'
13:06:05: Running command: save
13:06:05: Saving FITS: file M_100_304x10sec_2025-07-04_drizzle-1.0x__2025-07-04_1306_og.fit, 3 layer(s), 1309x2068 pixels, 32 bits
13:06:05: Running command: load
13:06:06: Error opening image M_100_304x10sec_2025-07-04_drizzle-1.0x__2025-07-04_1306_og.fits: file not found or not supported.
13:06:06: Command execution failed: file not found.
13:06:06: Exception in Tkinter callback
13:06:06: Traceback (most recent call last):
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril/venv/lib/python3.12/site-packages/sirilpy/connection.py", line 380, in _send_command
13:06:06:     self.sock.sendall(msg)
13:06:06: OSError: [Errno 9] Bad file descriptor
13:06:06: The above exception was the direct cause of the following exception:
13:06:06: Traceback (most recent call last):
13:06:06:   File "/usr/lib/python3.12/tkinter/__init__.py", line 1968, in __call__
13:06:06:     return self.func(*args)
13:06:06:            ^^^^^^^^^^^^^^^^
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril-scripts/preprocessing/Naztronomy-Smart_Telescope_PP.py", line 1058, in <lambda>
13:06:06:     command=lambda: self.run_script(
13:06:06:                     ^^^^^^^^^^^^^^^^
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril-scripts/preprocessing/Naztronomy-Smart_Telescope_PP.py", line 1205, in run_script
13:06:06:     self.load_image(image_name=img)
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril-scripts/preprocessing/Naztronomy-Smart_Telescope_PP.py", line 701, in load_image
13:06:06:     self.siril.log(f"Loaded image: {image_name}", LogColor.GREEN)
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril/venv/lib/python3.12/site-packages/sirilpy/connection.py", line 665, in log
13:06:06:     self._execute_command(_Command.LOG_MESSAGE, packed_message)
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril/venv/lib/python3.12/site-packages/sirilpy/connection.py", line 429, in _execute_command
13:06:06:     status, response = self._send_command(command, payload, timeout)
13:06:06:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:06:06:   File "/home/kevinh/.var/app/org.siril.Siril/data/siril/venv/lib/python3.12/site-packages/sirilpy/connection.py", line 405, in _send_command
13:06:06:     raise SirilConnectionError(_("Error in _send_command(): {}").format(e)) from e
13:06:06: sirilpy.exceptions.SirilConnectionError: Error in _send_command(): [Errno 9] Bad file descriptor