### PR TITLE
Refactor to QT6

### DIFF
--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -1225,7 +1225,6 @@ class PreprocessingInterface(QMainWindow):
         # Check files - if more than 2048, batch them:
         self.drizzle_status = drizzle
         self.drizzle_factor = drizzle_amount
-        self.start_time = datetime.now()
 
         # TODO: Stack calibration frames and copy to the various batch dirs
         if use_biases:
@@ -1401,9 +1400,7 @@ class PreprocessingInterface(QMainWindow):
 
         # self.clean_up()
         import datetime
-        end_time = datetime.now()
-        elapsed_time = end_time - self.start_time
-        self.siril.log(f"Elapsed time: {elapsed_time}", LogColor.BLUE)
+
         self.siril.log(
             f"Finished at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
             LogColor.GREEN,

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -1225,6 +1225,7 @@ class PreprocessingInterface(QMainWindow):
         # Check files - if more than 2048, batch them:
         self.drizzle_status = drizzle
         self.drizzle_factor = drizzle_amount
+        self.start_time = datetime.now()
 
         # TODO: Stack calibration frames and copy to the various batch dirs
         if use_biases:
@@ -1400,7 +1401,9 @@ class PreprocessingInterface(QMainWindow):
 
         # self.clean_up()
         import datetime
-
+        end_time = datetime.now()
+        elapsed_time = end_time - self.start_time
+        self.siril.log(f"Elapsed time: {elapsed_time}", LogColor.BLUE)
         self.siril.log(
             f"Finished at {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
             LogColor.GREEN,

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: GPL-3.0-or-later
 
 Smart Telescope Preprocessing script
-Version: 1.1.0
+Version: 1.2.0
 =====================================
 
 The author of this script is Nazmus Nasir (Naztronomy) and can be reached at:
@@ -24,6 +24,8 @@ The following subdirectories are optional:
 """
 CHANGELOG:
 
+1.2.0 - Minor version update:
+      - Refactored code to use Qt6 instead of Tkinter for the GUI
 1.1.0 - Minor version update:
       - Added Batching support for 2000+ files on Windows
       - Removed Autocrop due to reported errors
@@ -56,7 +58,7 @@ import numpy as np
 # from tkinter import filedialog
 
 APP_NAME = "Naztronomy - Smart Telescope Preprocessing"
-VERSION = "1.1.0"
+VERSION = "1.2.0"
 AUTHOR = "Nazmus Nasir"
 WEBSITE = "Naztronomy.com"
 YOUTUBE = "YouTube.com/Naztronomy"
@@ -279,11 +281,7 @@ class PreprocessingInterface(QMainWindow):
                     continue
 
         self.create_widgets()
-        
-        # Add keyboard shortcuts
         self.setup_shortcuts()
-        
-        # Mark initialization as successful
         self.initialization_successful = True
 
     # Dirname: lights, darks, biases, flats

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -48,8 +48,8 @@ from PySide6.QtWidgets import (
     QDoubleSpinBox, QComboBox, QGroupBox, QMessageBox,
     QFileDialog
 )
-from PySide6.QtCore import Slot
-from PySide6.QtGui import QFont
+from PySide6.QtCore import Slot, Qt
+from PySide6.QtGui import QFont, QShortcut, QKeySequence
 from sirilpy import LogColor, NoImageError
 from astropy.io import fits
 import numpy as np
@@ -277,6 +277,9 @@ class PreprocessingInterface(QMainWindow):
                     continue
 
         self.create_widgets()
+        
+        # Add keyboard shortcuts
+        self.setup_shortcuts()
 
     # Dirname: lights, darks, biases, flats
     def convert_files(self, dir_name):
@@ -958,6 +961,24 @@ class PreprocessingInterface(QMainWindow):
         
         # Add stretch to push everything to the top
         main_layout.addStretch()
+
+    def setup_shortcuts(self):
+        """Setup keyboard shortcuts"""
+        # Cmd+W on macOS, Ctrl+W on other platforms
+        close_shortcut = QShortcut(QKeySequence.StandardKey.Close, self)
+        close_shortcut.activated.connect(self.close_dialog)
+        
+        # Escape key as alternative to close
+        escape_shortcut = QShortcut(QKeySequence.StandardKey.Cancel, self)
+        escape_shortcut.activated.connect(self.close_dialog)
+        
+        # Enter/Return key to run
+        run_shortcut = QShortcut(QKeySequence(Qt.Key_Return), self)
+        run_shortcut.activated.connect(self.on_run_clicked)
+        
+        # Cmd+R on macOS, Ctrl+R on other platforms for run
+        run_shortcut2 = QShortcut(QKeySequence("Ctrl+R"), self)
+        run_shortcut2.activated.connect(self.on_run_clicked)
 
     def on_run_clicked(self):
         """Handle the Run button click"""


### PR DESCRIPTION
Refactored to use qt6. I've done pretty comprehensive testing (below), and everything seems to work as expected.

<img width="582" height="613" alt="image" src="https://github.com/user-attachments/assets/fe2ae134-ffa3-4a74-9b64-afa535bea718" />


# Testing Checklist

## 🔧 **Basic UI Testing**

### **Window & Layout**
- [x] Application launches without errors
- [x] Window resizes properly (minimum 575x500)
- [x] All sections are visible and properly aligned
- [x] No overlapping widgets or text cutoff
- [x] Current working directory displays correctly

### **Telescope Section**
- [x] Telescope dropdown opens and shows all options:
  - ZWO Seestar S30
  - ZWO Seestar S50 
  - Dwarf 3
  - Dwarf 2
  - Celestron Origin
- [x] Calibration frame checkboxes (Darks, Flats, Biases) toggle properly
- [x] Clean Up Files checkbox toggles
- [x] Proper spacing between Calibration Frames and Clean Up Files

## 🔄 **Interactive Behavior Testing**

### **Telescope → Filter Dependency**
1. [x] Select "ZWO Seestar S30" → Check SPCC → OSC Filter should show:
   - "No Filter (Broadband)"
   - "LP (Narrowband)"
2. [x] Select "Dwarf 3" → Check SPCC → OSC Filter should show:
   - "Astro filter (UV/IR)"
   - "Dual-Band"
3. [x] Select "Dwarf 2" → Check SPCC → OSC Filter should show:
   - "Astro filter (UV/IR)" only
4. [x] Select "Celestron Origin" → Check SPCC → OSC Filter should show:
   - "No Filter (Broadband)" only

### **Drizzle Dependencies**
- [x] **Drizzle unchecked**: Both "Drizzle amount" and "Pixel Fraction" spinboxes disabled
- [x] **Drizzle checked**: Both spinboxes become enabled
- [x] Drizzle amount range: 0.1 - 3.0 (step 0.1)
- [x] Pixel fraction range: 0.1 - 10.0 (step 0.01)

### **Feather Dependencies**
- [x] **Feather unchecked**: "Feather amount" spinbox disabled
- [x] **Feather checked**: Spinbox becomes enabled
- [x] Feather amount range: 5 - 2000 (step 5)

### **SPCC Dependencies** 
- [x] **SPCC unchecked**: OSC Filter and Catalog dropdowns disabled (grayed out)
- [x] **SPCC checked**: Both dropdowns become enabled
- [x] Catalog dropdown shows: "localgaia", "gaia"
- [x] Green "✓ Local Gaia Available" or red "✗ Local Gaia Not available" displays

## 🎯 **Critical Feature Testing**

### **To Enable Catalog Dropdown:**
1. [x] Check "Enable Spectrophotometric Color Calibration (SPCC)" checkbox
2. [x] Catalog dropdown should become active
3. [x] Select between "localgaia" and "gaia" options

### **Button Testing**
- [x] **Help Button**: Opens help dialog with author info and instructions
- [x] **Close Button**: Closes application and disconnects from Siril
- [x] **Run Button**: Starts processing (will fail without Siril connection, but should call the function)

### **Tooltip Testing**
- [x] Hover over "Clean Up Files" checkbox → tooltip appears with explanation
- [x] Tooltips display properly and don't interfere with UI

## 📁 **Directory Testing**

### **Working Directory Scenarios**
1. [x] **Valid directory with /lights subdirectory**: Should proceed normally
2. [x] **Currently in /lights directory**: Should prompt to use parent directory
3. [x] **Invalid directory**: Should show directory selection dialog
4. [x] **Cancel directory selection**: Should close application gracefully

## ⚙️ **Integration Testing**

### **Siril Connection Testing**
- [x] **With Siril running**: Should connect successfully
- [x] **Siril version check**: Should verify version 1.3.6+ requirement

### **Data Validation**
- [x] All spinboxes respect their min/max ranges
- [x] Dropdown selections persist when switching between options
- [x] Checkbox states are properly tracked
- [x] Form data is correctly passed to `run_script()` method

## 🎨 **Visual Polish Testing**
- [x] Group box headers are bold
- [x] Proper spacing between sections
- [x] Consistent spinbox widths (80px minimum)
- [x] Button heights are consistent (35px)
- [x] Run button appears bold
- [x] Color coding: Green for available Gaia, Red for unavailable

## 🚨 **Error Handling**
- [x] Application handles missing dependencies gracefully
- [x] Invalid directory selections show proper error messages
- [x] Siril connection failures display appropriate warnings
- [x] Application doesn't crash on invalid inputs