### PR TITLE
Add fits compression for intermediate files

### DIFF
--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -172,6 +172,7 @@ class PreprocessingInterface(QMainWindow):
             return
         try:
             self.siril.cmd("requires", "1.3.6")
+            self.siril.cmd("setcompress", "1 -type=rice 16")
         except s.CommandError:
             self.close_dialog()
             return
@@ -714,6 +715,7 @@ class PreprocessingInterface(QMainWindow):
         file_name += f"__{current_datetime}{suffix}"
 
         try:
+            self.siril.cmd("setcompress", "0")
             self.siril.cmd(
                 "save",
                 f"{file_name}",


### PR DESCRIPTION
Hi, I did a simple but very useful modification to your script in order to use fits compression for intermediate files into process folder, this saves a lot of space but also speed up processing. I revert the compression to 0 just before saving the stacked file.