### PR TITLE
Add fits compression for intermediate files

### DIFF
--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -586,12 +586,12 @@ class PreprocessingInterface(QMainWindow):
 
         for idx, filename in enumerate(sorted(os.listdir(folder))):
             if filename.startswith(seq_name) and filename.lower().endswith(
-                self.fits_extension
+                self.fits_extension + ".fz"
             ):
                 filepath = os.path.join(folder, filename)
                 try:
                     with fits.open(filepath) as hdul:
-                        data = hdul[0].data
+                        data = hdul[1].data
                         if data is not None and data.ndim >= 2:
                             dynamic_threshold = threshold
                             data_max = np.max(data)


### PR DESCRIPTION
I added a simple set compression command for intermediate files. This saves a lot of spaces and even speed up processing. The compression does not affect quality as it is lossless. The compression is reverted to 0 when the final stacked file is saved to keep greater compatibility with other external tools.