### PR TITLE
Fix stacking crash and silent error-handling failures in Naztronomy-OSC_PP

### DIFF
--- a/Naztronomy-OSC_PP.py
+++ b/Naztronomy-OSC_PP.py
@@ -779,11 +779,21 @@ class PreprocessingInterface(QMainWindow):
                                 black_indices.append(len(all_frames_info))
                         else:
                             self.siril.log(
-                                f"{filename}: Unexpected data shape {data.shape if data is not None else 'None'}",
+                                f"WARNING: Skipping {filename} — unexpected data shape "
+                                f"{data.shape if data is not None else 'None'}",
                                 LogColor.SALMON,
                             )
+                            all_frames_info.append((filename, None))
+                            black_frames.append(filename)
+                            black_indices.append(len(all_frames_info))
                 except Exception as e:
-                    self.siril.log(f"Error reading {filename}: {e}", LogColor.RED)
+                    self.siril.log(
+                        f"WARNING: Skipping {filename} — could not read file: {e}",
+                        LogColor.RED,
+                    )
+                    all_frames_info.append((filename, None))
+                    black_frames.append(filename)
+                    black_indices.append(len(all_frames_info))
 
         self.siril.log(f"Following files are black: {black_frames}", LogColor.SALMON)
         self.siril.log(
@@ -833,6 +843,7 @@ class PreprocessingInterface(QMainWindow):
             except (s.DataError, s.CommandError, s.SirilError) as e:
                 self.siril.log(f"Command execution failed: {e}", LogColor.RED)
                 self.close_dialog()
+                return
 
         self.siril.log(f"Completed stacking {seq_name}!", LogColor.GREEN)
         # Copy the stacked calibration files to ../masters directory
@@ -954,33 +965,38 @@ class PreprocessingInterface(QMainWindow):
         output_norm=True,
         stack_weighted=False,
         weighting_method="Weighted FWHM",
+        norm_mode="addscale",
     ):
         """Stack it all, and feather if it's provided"""
         out = "result" if output_name is None else output_name
 
-        cmd_args = [
-            "stack",
-            f"{seq_name}",
-            " rej 3 3" if rejection else " rej none",
-            "-norm=addscale",
-            "-output_norm" if output_norm else "",
-            "-overlap_norm" if overlap_norm else "",
-            "-rgb_equal",
-            "-maximize",
-            "-filter-included",
-            "-32b",
-            f"-out={out}",
-        ]
-        if stack_weighted:
-            weighting_map = {
-                "Number of Stars": "nbstars",
-                "Weighted FWHM": "wfwhm",
-                "Noise": "noise",
-            }
-            weight_option = weighting_map.get(weighting_method, "wfwhm")
-            cmd_args.append(f"-weight={weight_option}")
-        if feather:
-            cmd_args.append(f"-feather={feather_amount}")
+        def build_cmd_args(norm):
+            args = [
+                "stack",
+                f"{seq_name}",
+                " rej 3 3" if rejection else " rej none",
+                f"-norm={norm}",
+                "-output_norm" if output_norm else "",
+                "-overlap_norm" if overlap_norm else "",
+                "-rgb_equal",
+                "-maximize",
+                "-filter-included",
+                "-32b",
+                f"-out={out}",
+            ]
+            if stack_weighted:
+                weighting_map = {
+                    "Number of Stars": "nbstars",
+                    "Weighted FWHM": "wfwhm",
+                    "Noise": "noise",
+                }
+                weight_option = weighting_map.get(weighting_method, "wfwhm")
+                args.append(f"-weight={weight_option}")
+            if feather:
+                args.append(f"-feather={feather_amount}")
+            return args
+
+        cmd_args = build_cmd_args(norm_mode)
 
         self.siril.log(
             f"Running seq_stack with arguments:\n"
@@ -996,8 +1012,29 @@ class PreprocessingInterface(QMainWindow):
         try:
             self.siril.cmd(*cmd_args)
         except (s.DataError, s.CommandError, s.SirilError) as e:
-            self.siril.log(f"Stacking failed: {e}", LogColor.RED)
-            self.close_dialog()
+            if norm_mode != "none":
+                # Drizzle mosaic frames with >50% zero padding cause the global
+                # median to be 0, which breaks addscale normalization (Siril
+                # reports "Generic error" in the exception but logs
+                # "Normalization failed"). Fall back to no normalization so
+                # the stack can still complete.
+                self.siril.log(
+                    f"Stacking failed with norm={norm_mode}: {e}. "
+                    f"Retrying without normalization (this is expected for "
+                    f"drizzle mosaic frames with large zero-padded borders)...",
+                    LogColor.SALMON,
+                )
+                fallback_args = build_cmd_args("none")
+                try:
+                    self.siril.cmd(*fallback_args)
+                except (s.DataError, s.CommandError, s.SirilError) as e2:
+                    self.siril.log(f"Stacking failed on retry: {e2}", LogColor.RED)
+                    self.close_dialog()
+                    return
+            else:
+                self.siril.log(f"Stacking failed: {e}", LogColor.RED)
+                self.close_dialog()
+                return
 
         self.siril.log(f"Completed stacking {seq_name}!", LogColor.GREEN)
 


### PR DESCRIPTION
## What broke and why

Three related bugs in the error-handling path of the stacking pipeline, all found while debugging a real failure: `OSError: [Errno 9] Bad file descriptor` crashing the script after a normalization failure during a drizzle mosaic stack.

## Fixes

**1. Missing `return` after `close_dialog()` in `seq_stack` and `calibration_stack`**

After catching a stacking error, `close_dialog()` disconnects from Siril — but execution fell through to the success log line (`self.siril.log(f"Completed stacking...")`) on the now-closed socket, raising `OSError: [Errno 9] Bad file descriptor`. Added `return` after `close_dialog()` in both functions.

**2. Normalization failure on drizzle mosaic frames (`seq_stack`)**

Drizzle registration creates a growing canvas across a session, so frames from one panel can end up with >50% zero-padded pixels. This makes the global image median = 0, which breaks `-norm=addscale` (Siril logs `"Normalization failed. Check image N first."` but raises only a generic exception in Python).

Added a `norm_mode` parameter (default: `addscale`, preserving existing behaviour) and a fallback retry with `-norm=none` when the first attempt fails. Since the frames have legitimate signal in their non-zero regions, skipping normalization is preferable to aborting the entire stack.

**3. `scan_black_frames` not deselecting unreadable/malformed files**

When a file failed to open or had an unexpected data shape, the error was logged but the file index was never appended to `all_frames_info` — so `len(all_frames_info)` didn't advance, the index was never added to `black_indices`, and the bad file was still passed to Siril's `stack` command (causing it to crash). Fixed by always appending to `all_frames_info` before adding to `black_indices` in both error branches.

## Tested against

Reproduced on a 694-frame M45 drizzle mosaic session where frames 400+ had ~53% zero padding, causing the normalization failure that triggered the cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)