### PR TITLE
Improve DWARF experience using code from DeepSkyLab

### DIFF
--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -331,7 +331,7 @@ class PreprocessingInterface(QMainWindow):
         if not changed_cwd:
             while True:
                 prompt_title = (
-                    "Select the parent directory containing the 'lights' directory"
+                    "Select the parent directory containing the 'lights' directory (or the 'shotsInfo.json' file if you have a DWARF telescope)"
                 )
 
                 selected_dir = QFileDialog.getExistingDirectory(
@@ -402,7 +402,7 @@ class PreprocessingInterface(QMainWindow):
             )
             return False
         elif self.load_dwarf(directory):
-            msg = "You don't have 'lights' directory, but I've found a shotsinfo.json so you may be using a DWARF Telescope, do you want me to try to create the 'lights' directory for you and put your fits files in it?"
+            msg = "You don't have 'lights' directory, but I've found a shotsinfo.json so you must be using a DWARF Telescope, do you want me to try to create the 'lights' directory for you and put your fits files in it?"
             file_number = 0
             answer = QMessageBox.question(self, "Copy Dwarf fits into Lights Dir", msg)
             if answer == QMessageBox.StandardButton.Yes:
@@ -415,7 +415,7 @@ class PreprocessingInterface(QMainWindow):
                 LogColor.SALMON,
             )
 
-        msg = f"The selected directory must contain a subdirectory named 'lights'.\nYou selected: {directory}. Please try again."
+        msg = f"The selected directory must contain either a subdirectory named 'lights' or a file 'shotsInfo.json' (DWARF telescope).\nYou selected: {directory}. Please try again."
         self.siril.log(msg, LogColor.SALMON)
         QMessageBox.critical(
             self, "Invalid Directory", msg, QMessageBox.StandardButton.Ok
@@ -431,7 +431,9 @@ class PreprocessingInterface(QMainWindow):
         Q: How do I get support?
         A: Join the Naztronomy Discord server for support and discussion. Please have your logs handy.
         Q: Where can I find the logs?
-        A: You can export logs by clicking the download button on the lower right hand side of the console.\n
+        A: You can export logs by clicking the download button on the lower right hand side of the console.
+        Q: How can I use bias/flat for DWARF Telescopes?
+        A: Keep a copy of the telescope CALI_FRAME/ directory into the parent directory of your selected directory, the needed files will automatically be fetched\n
         """
         self.siril_log_long(msg, LogColor.BLUE)
 

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -32,10 +32,10 @@ CHANGELOG:
       - PR#75 - support compressed fits in lights dir
       - Refactored UI code for better maintainability
       - Allow safe cancellation of processing
-      - Added safe deletes
+      - Added safe deletes 
       - Added stack weighting option (Noise, Number of Stars, Weighted FWHM)
       - Max batch size of 8100 on Windows but default in UI is still 2000 until version is readable by Python OR feature becomes permanent
-      - Added Dwarf II in telescope name along with DWARFII.
+      - Added Dwarf II in telescope name along with DWARFII. 
 2.0.5 - Bugfix: Black Frames Scan now sees both compressed and uncompressed fits
       - Bugfix: Compression turned on at batch instead of run code
 2.0.4 - Compression is now an optional checkbox
@@ -51,7 +51,7 @@ CHANGELOG:
       - Updated and more Tooltips
       - Output stacking details
       - Fixed max frames bug for linux and mac
-      - Updated tolerance for BGE
+      - Updated tolerance for BGE 
       - Add Dwarf Mini Support
 2.0.2 - Small Bug fixes
       - Reenable feathering
@@ -76,7 +76,7 @@ CHANGELOG:
       - Allow changing batch size
       - Accepts master calibration frames (also creates master calibration frames)
       - Temporary workaround to cfa debayering bug in Siril when using drizzle and background extraction for seestars
-1.1.1 - Bug fixes:
+1.1.1 - Bug fixes: 
       - Fixed Celestron Origin focal length to 335mm
       - Fixed clean up for pre-pp files
 1.1.0 - Minor version update:
@@ -377,7 +377,7 @@ class PreprocessingInterface(QMainWindow):
                 LogColor.GREEN,
             )
 
-    def check_directory(self, directory: str, is_initial_dir=False) -> bool:
+    def check_directory(self, directory: str, is_initial_dir=False) -> bool: 
         lights_directory = os.path.join(directory, "lights")
         if os.path.isdir(lights_directory):
             self.confirm_selected_directory(directory)
@@ -427,7 +427,7 @@ class PreprocessingInterface(QMainWindow):
         Please watch latest demos on https://youtube.com/Naztronomy which can answer most questions.
         Here are some Frequently Asked Questions:
         Q: Can it handle telescopes not listed in the dropdown?
-        A: Yes, but it will not mosaic them. It will do regular star registration.
+        A: Yes, but it will not mosaic them. It will do regular star registration. 
         Q: How do I get support?
         A: Join the Naztronomy Discord server for support and discussion. Please have your logs handy.
         Q: Where can I find the logs?
@@ -667,7 +667,6 @@ class PreprocessingInterface(QMainWindow):
                 LogColor.GREEN,
             )
             return True
-
         else:
             self.siril.log(
                 f'No directory named "{dir_name}" at this location. Make sure the working directory is correct. Skipping.',
@@ -2434,10 +2433,10 @@ class PreprocessingInterface(QMainWindow):
         )
         self.siril.log(
             """
-        Thank you for using the Naztronomy Smart Telescope Preprocessor!
+        Thank you for using the Naztronomy Smart Telescope Preprocessor! 
         The author of this script is Nazmus Nasir (Naztronomy).
-        Website: https://www.Naztronomy.com
-        YouTube: https://www.YouTube.com/Naztronomy
+        Website: https://www.Naztronomy.com 
+        YouTube: https://www.YouTube.com/Naztronomy 
         Discord: https://discord.gg/yXKqrawpjr
         Patreon: https://www.patreon.com/c/naztronomy
         Buy me a Coffee: https://www.buymeacoffee.com/naztronomy
@@ -3086,7 +3085,6 @@ class DwarfManager:
 
         return naxis3
 
-
     def _select_light_files(self) -> Tuple[List[Path], Dict[int, int], List[Path]]:
         """Return (selected_subs, layer_hist, excluded_fits).
 
@@ -3133,6 +3131,7 @@ class DwarfManager:
             selected = candidates
 
         return sorted(selected), hist, sorted(set(excluded))
+
 
 def main():
     try:

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -597,6 +597,11 @@ class PreprocessingInterface(QMainWindow):
     # Dirname: lights, darks, biases, flats
     def convert_files(self, dir_name):
         directory = os.path.join(self.current_working_directory, dir_name)
+
+        if not os.path.isdir(directory) and self.dwarf is not None and dir_name in ["biases", "flats"]:
+            self.siril.log(f"DWARF telescope: try to find {dir_name} into ../CALI_FRAME/", LogColor.BLUE)
+            self.dwarf.copy_calibration_files(dir_name) #  If Dwarf, first let's try to fetch the correct calibration files
+
         if os.path.isdir(directory):
             self.siril.cmd("cd", dir_name)
             file_count = len(
@@ -660,6 +665,7 @@ class PreprocessingInterface(QMainWindow):
                 LogColor.GREEN,
             )
             return True
+
         else:
             self.siril.log(
                 f'No directory named "{dir_name}" at this location. Make sure the working directory is correct. Skipping.',
@@ -2193,6 +2199,7 @@ class PreprocessingInterface(QMainWindow):
             LogColor.BLUE,
         )
         self.siril.cmd("close")
+        self.load_dwarf(self.current_working_directory)
 
         def check_interruption():
             if check_cancel and check_cancel():
@@ -2831,6 +2838,7 @@ class DwarfManager:
             re.IGNORECASE,
         )
         self._TEMP_SUFFIX_RE = re.compile(r".*_[+-]?\d+C\.(fit|fits|fts)$", re.IGNORECASE)
+        self.cam = self._detect_cam_name(workdir)
 
     def _log(self, msg, color = LogColor.RED):
         self.siril.log(msg, color)
@@ -2891,7 +2899,6 @@ class DwarfManager:
             return "cam_1"
         return "cam_0"
 
-
     def _detect_ir_code(self, ir_str: str) -> Optional[int]:
         s0 = (ir_str or "").strip().lower()
         if not s0:
@@ -2904,12 +2911,31 @@ class DwarfManager:
             return 0
         return None
 
-    def _pick_best_calib_subfolder(self, parent: Path, cam_name: str, ir_code: Optional[int], gain: int) -> Optional[Path]:
+    def copy_calibration_files(self, dir_name):
+        parent = self.current_folder.parent / "CALI_FRAME"
+        root_paths = {
+            'biases': parent / "bias",
+            'flats': parent / "flat",
+            'darks': parent / "dark"
+        }
+
+        best_directory = self._pick_best_calib_subfolder(root_paths[dir_name])
+        if best_directory is not None:
+            self.siril.log(f"Copy {best_directory.name} into {(self.current_folder / dir_name).name}", LogColor.GREEN)
+            shutil.copytree(best_directory, self.current_folder / dir_name)
+
+    def _pick_best_calib_subfolder(self, parent: Path) -> Optional[Path]:
         """Pick best matching subfolder in CALI_FRAME/{bias|flat}."""
+
+        cam_name = self.cam
+        ir_code = self._detect_ir_code(self.dwarf_shots_info.ir)
+        gain = self.dwarf_shots_info.gain
+
         if not parent.is_dir():
             return None
 
         candidates = [p for p in parent.iterdir() if p.is_dir() and p.name.lower().startswith(cam_name.lower())]
+
         if not candidates:
             return None
 
@@ -2918,6 +2944,7 @@ class DwarfManager:
             sc = 0
             if name == cam_name.lower():
                 sc += 5
+
             if ir_code is not None:
                 if f"ir_{ir_code}" in name:
                     sc += 10
@@ -2927,6 +2954,7 @@ class DwarfManager:
                 sc += 3
             elif "gain_" in name:
                 sc -= 1
+
             # prefer slightly more specific folders
             sc += len(name) // 10
             return sc

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -87,6 +87,7 @@ CHANGELOG:
 """
 
 import os
+from pathlib import Path
 import sys
 import math
 import shutil
@@ -94,6 +95,8 @@ import time
 import sirilpy as s
 from datetime import datetime
 import json
+from typing import Dict, List, Optional, Tuple
+import re
 
 
 s.ensure_installed("PyQt6", "numpy", "astropy")
@@ -353,7 +356,7 @@ class PreprocessingInterface(QMainWindow):
                     f"Current working directory is invalid: {self.current_working_directory}, reprompting...",
                     LogColor.SALMON,
                 )
-                changed_cwd = False
+                changed_cwd = False      
 
         if not changed_cwd:
             while True:
@@ -2778,6 +2781,275 @@ class PreprocessingInterface(QMainWindow):
         except Exception as e:
             self.siril.log(f"Failed to load presets: {e}", LogColor.RED)
 
+class DwarfShotsInfo:
+    target: str
+    exp_s: float
+    gain: int
+    ir: str
+    binning: int
+    min_temp: Optional[int]
+    max_temp: Optional[int]
+    shots_taken: Optional[int]
+    shots_stacked: Optional[int]
+
+    @property
+    def mean_temp(self) -> Optional[float]:
+        if self.min_temp is None or self.max_temp is None:
+            return None
+        return (self.min_temp + self.max_temp) / 2.0
+    
+class DwarfDarkMeta:
+    exp_s: float
+    gain: int
+    binning: int
+    temp_c: int
+    
+class DwarfUtils: 
+    # This class encapsulates code initially created by DeepSkyLab for his "DWARF Mini One‑Click Preprocess for Siril" script
+    # https://youtu.be/GnNZ2issC-Y
+
+    def __init__(self, workdir: Path):
+        self.dwarfShotsInfo = self._read_DwarfShotsInfo(workdir)
+        self._DARK_RE = re.compile(
+            r"dark_exp_(?P<exp>[0-9]+\.?[0-9]*)_gain_(?P<gain>[0-9]+)_bin_(?P<bin>[0-9]+)_(?P<temp>[0-9]+)C",
+            re.IGNORECASE,
+        )        
+        self._TEMP_SUFFIX_RE = re.compile(r".*_[+-]?\d+C\.(fit|fits|fts)$", re.IGNORECASE)
+
+    def _read_shotsinfo(self, shotsinfo_path: Path) -> DwarfShotsInfo:
+        with shotsinfo_path.open("r", encoding="utf-8") as f:
+            d = json.load(f)
+
+        target = str(d.get("target", "UNKNOWN"))
+        exp_s = float(d.get("exp", 0))
+        gain = int(d.get("gain", 0))
+        ir = str(d.get("ir", "UNKNOWN"))
+
+        binning_raw = str(d.get("binning", "1*1"))
+        try:
+            binning = int(binning_raw.split("*")[0])
+        except Exception:
+            binning = 1
+
+        min_temp = d.get("minTemp", None)
+        max_temp = d.get("maxTemp", None)
+        min_temp = int(min_temp) if min_temp is not None else None
+        max_temp = int(max_temp) if max_temp is not None else None
+
+        shots_taken = d.get("shotsTaken", None)
+        shots_stacked = d.get("shotsStacked", None)
+        shots_taken = int(shots_taken) if shots_taken is not None else None
+        shots_stacked = int(shots_stacked) if shots_stacked is not None else None
+
+        return DwarfShotsInfo(
+            target=target,
+            exp_s=exp_s,
+            gain=gain,
+            ir=ir,
+            binning=binning,
+            min_temp=min_temp,
+            max_temp=max_temp,
+            shots_taken=shots_taken,
+            shots_stacked=shots_stacked,
+        )
+
+    def _detect_cam_name(self, folder_name: str) -> str:
+        n = folder_name.upper()
+        if "TELE" in n:
+            return "cam_0"
+        if "WIDE" in n:
+            return "cam_1"
+        return "cam_0"
+
+
+    def _detect_ir_code(self, ir_str: str) -> Optional[int]:
+        s0 = (ir_str or "").strip().lower()
+        if not s0:
+            return None
+        if "astro" in s0:
+            return 1
+        if "dual" in s0 or "duo" in s0 or "band" in s0 or "narrow" in s0:
+            return 2
+        if "none" in s0 or "off" in s0 or "clear" in s0 or "ircut" in s0:
+            return 0
+        return None
+
+
+    def _pick_best_calib_subfolder(self, parent: Path, cam_name: str, ir_code: Optional[int], gain: int) -> Optional[Path]:
+        """Pick best matching subfolder in CALI_FRAME/{bias|flat}."""
+        if not parent.is_dir():
+            return None
+
+        candidates = [p for p in parent.iterdir() if p.is_dir() and p.name.lower().startswith(cam_name.lower())]
+        if not candidates:
+            return None
+
+        def score(p: Path) -> int:
+            name = p.name.lower()
+            sc = 0
+            if name == cam_name.lower():
+                sc += 5
+            if ir_code is not None:
+                if f"ir_{ir_code}" in name:
+                    sc += 10
+                elif "ir_" in name:
+                    sc -= 2
+            if f"gain_{gain}" in name:
+                sc += 3
+            elif "gain_" in name:
+                sc -= 1
+            # prefer slightly more specific folders
+            sc += len(name) // 10
+            return sc
+
+        return sorted(candidates, key=score, reverse=True)[0]
+    
+    def _parse_dark_filename(self, name: str) -> Optional[DwarfDarkMeta]:
+        m = self._DARK_RE.search(name)
+        if not m:
+            return None
+        try:
+            return DwarfDarkMeta(
+                exp_s=float(m.group("exp")),
+                gain=int(m.group("gain")),
+                binning=int(m.group("bin")),
+                temp_c=int(m.group("temp")),
+            )
+        except Exception:
+            return None
+
+
+    def _select_matching_darks(self, dark_dir: Path) -> List[Path]:
+        shots = self.dwarfShotsInfo
+        files = self._glob_fits(dark_dir)
+        if not files:
+            return []
+
+        exp_tol = max(0.05, shots.exp_s * 0.02)  # DWARF uses odd decimals sometimes
+
+        candidates: List[Tuple[Path, DwarfDarkMeta]] = []
+        for f in files:
+            meta = self._parse_dark_filename(f.name)
+            if not meta:
+                continue
+            if meta.gain != shots.gain:
+                continue
+            if meta.binning != shots.binning:
+                continue
+            if abs(meta.exp_s - shots.exp_s) > exp_tol:
+                continue
+            candidates.append((f, meta))
+
+        if not candidates:
+            return []
+
+        # Prefer temps inside session range
+        # Tiny bonus: matching dark temperature matters more than most people think (until it *really* does).
+        if shots.min_temp is not None and shots.max_temp is not None:
+            in_range = [f for (f, m) in candidates if shots.min_temp <= m.temp_c <= shots.max_temp]
+            if in_range:
+                return sorted(in_range)
+
+        # Else closest to mean temp (or median)
+        temps = [m.temp_c for (_, m) in candidates]
+        target_t = shots.mean_temp if shots.mean_temp is not None else sorted(temps)[len(temps) // 2]
+        best_dist = min(abs(m.temp_c - target_t) for (_, m) in candidates)
+        chosen = [f for (f, m) in candidates if abs(m.temp_c - target_t) == best_dist]
+        return sorted(chosen)
+
+    def _fits_layer_count(path: Path) -> Optional[int]:
+        """Cheap FITS header peek to estimate # layers.
+
+        - NAXIS<=2 -> 1 layer
+        - NAXIS=3 and NAXIS3=3 -> 3 layers
+
+        Returns None if it can't parse.
+        """
+        try:
+            header_cards: List[str] = []
+            with path.open("rb") as f:
+                for _ in range(20):
+                    block = f.read(2880)
+                    if not block:
+                        break
+                    for i in range(0, len(block), 80):
+                        card = block[i : i + 80].decode("ascii", errors="ignore")
+                        header_cards.append(card)
+                        if card.startswith("END"):
+                            raise StopIteration
+        except StopIteration:
+            pass
+        except Exception:
+            return None
+
+        kv: Dict[str, str] = {}
+        for c in header_cards:
+            if "=" in c[:10]:
+                key = c[:8].strip()
+                val = c.split("=", 1)[1].split("/", 1)[0].strip()
+                kv[key] = val
+
+        try:
+            naxis = int(kv.get("NAXIS", "2"))
+        except Exception:
+            return None
+
+        if naxis <= 2:
+            return 1
+
+        try:
+            naxis3 = int(kv.get("NAXIS3", "1"))
+        except Exception:
+            naxis3 = 1
+
+        return naxis3
+
+
+    def _select_light_files(self, target_dir: Path) -> Tuple[List[Path], Dict[int, int], List[Path]]:
+        """Return (selected_subs, layer_hist, excluded_fits).
+
+        Excludes DWARF products like stacked*.fits and filters by majority layer count
+        to prevent Siril sequence aborts.
+        """
+        allfits = self._glob_fits(target_dir)
+
+        excluded: List[Path] = []
+
+        # Exclude obvious non-subs
+        nonstack: List[Path] = []
+        for p in allfits:
+            n = p.name.lower()
+            if "stacked" in n:
+                excluded.append(p)
+                continue
+            if n.startswith("pp_") or n.startswith("r_") or n.startswith("dsl_"):
+                excluded.append(p)
+                continue
+            nonstack.append(p)
+
+        # Prefer classic DWARF raw-sub naming: ..._27C.fits
+        temp_named = [p for p in nonstack if self._TEMP_SUFFIX_RE.match(p.name)]
+        candidates = temp_named if len(temp_named) >= max(5, len(nonstack) // 2) else nonstack
+
+        # Layer-count majority filter
+        layers: Dict[Path, Optional[int]] = {p: self._fits_layer_count(p) for p in candidates}
+        hist: Dict[int, int] = {}
+        for _, n in layers.items():
+            if n is None:
+                continue
+            hist[n] = hist.get(n, 0) + 1
+
+        if hist:
+            majority = sorted(hist.items(), key=lambda kv: kv[1], reverse=True)[0][0]
+            selected = [p for p in candidates if layers.get(p, None) == majority]
+            # Any candidate with a different layer count is excluded
+            for p in candidates:
+                if layers.get(p, None) != majority:
+                    excluded.append(p)
+        else:
+            selected = candidates
+
+        return sorted(selected), hist, sorted(set(excluded))
 
 def main():
     try:

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -271,6 +271,7 @@ class PreprocessingInterface(QMainWindow):
         self.target_coords = None
         self.telescope_combo = None
         self.filter_combo = None
+        self.dwarf = None
 
         self.filter_options_map = FILTER_OPTIONS_MAP
         self.current_filter_options = self.filter_options_map["ZWO Seestar S50"]
@@ -358,12 +359,11 @@ class PreprocessingInterface(QMainWindow):
                     LogColor.SALMON,
                 )
                 changed_cwd = False
-        elif os.path.exists(os.path.join(self.current_working_directory, "shotsInfo.json")):
+        elif self.load_dwarf(self.current_working_directory):
             msg = "You don't have 'lights' directory, but I've found a shotsinfo.json so you may be using a DWARF Telescope, do you want me to try to create the 'lights' directory for you and put your fits files in it?"
             answer = QMessageBox.question(self, "Copy Dwarf fits into Lights Dir", msg)
-            if answer == QMessageBox.StandardButton.Yes:
-                dwarf = DwarfUtils(self.current_working_directory, self.siril)
-                dwarf.create_lights_folder()
+            if answer == QMessageBox.StandardButton.Yes:                
+                self.dwarf.create_lights_folder()
                 changed_cwd = True
             else:
                 self.siril.log(
@@ -426,12 +426,11 @@ class PreprocessingInterface(QMainWindow):
                         )
                     break
 
-                elif os.path.exists(os.path.join(selected_dir, "shotsInfo.json")):
+                elif self.load_dwarf(selected_dir):
                     msg = "You don't have 'lights' directory, but I've found a shotsinfo.json so you may be using a DWARF Telescope, do you want me to try to create the 'lights' directory for you and put your fits files in it?"
                     answer = QMessageBox.question(self, "Copy Dwarf fits into Lights Dir", msg)
-                    if answer == QMessageBox.StandardButton.Yes:
-                        dwarf = DwarfUtils(selected_dir, self.siril)
-                        dwarf.create_lights_folder()                        
+                    if answer == QMessageBox.StandardButton.Yes:                        
+                        self.dwarf.create_lights_folder()                        
                         self.siril.cmd("cd", f'"{selected_dir}"')
                         os.chdir(selected_dir)
                         self.current_working_directory = selected_dir
@@ -449,7 +448,11 @@ class PreprocessingInterface(QMainWindow):
                         self, "Invalid Directory", msg, QMessageBox.StandardButton.Ok
                     )
                     continue
+        # (Re)Load Dwarf info if available
+        self.load_dwarf(self.current_working_directory)
+
         self.create_widgets()
+
         # Initialize fits_files_count before creating widgets
         self.fits_files_count = 0
         self.set_telescope_from_fits()
@@ -1367,6 +1370,15 @@ class PreprocessingInterface(QMainWindow):
         # Set default selection
         if new_options:
             self.filter_combo.setCurrentText(new_options[0])
+
+        if selected_scope[0:5] == "Dwarf" and self.dwarf is not None: # If Dwarf, try to autodetect the filter            
+            filter = self.dwarf.dwarf_shots_info.ir.strip().lower()
+            if "dual" in filter or "duo" in filter or "band" in filter or "narrow" in filter:
+                self.filter_combo.setCurrentText(new_options[1]) # It seems to be Dual Band Filter
+                self.siril.log(
+                    "Dual Band Filter detected",
+                    LogColor.BLUE,
+                )
 
         # Disable SPCC for Celestron Origin
         if selected_scope == "Celestron Origin":
@@ -2812,6 +2824,16 @@ class PreprocessingInterface(QMainWindow):
         except Exception as e:
             self.siril.log(f"Failed to load presets: {e}", LogColor.RED)
 
+    def load_dwarf(self, directory: str) -> bool:
+        if not os.path.exists(Path(os.path.join(directory, "shotsInfo.json"))):
+            self.siril.log("PAS DWARF LOADED", LogColor.RED)
+            self.dwarf = None
+            return False
+        self.siril.log("DWARF LOADED :)", LogColor.GREEN)
+        self.dwarf = DwarfManager(directory, self.siril)
+
+        return True
+
 @dataclass
 class DwarfShotsInfo:
     target: str
@@ -2837,14 +2859,14 @@ class DwarfDarkMeta:
     binning: int
     temp_c: int
     
-class DwarfUtils: 
+class DwarfManager: 
     # This class encapsulates code initially created by DeepSkyLab for his "DWARF Mini One‑Click Preprocess for Siril" script
     # https://youtu.be/GnNZ2issC-Y
 
     def __init__(self, workdir: str, siril):
         self.siril = siril
         self.current_folder = Path(workdir)
-        self.dwarfShotsInfo = self._read_shotsinfo(Path(os.path.join(self.current_folder, "shotsInfo.json")))
+        self.dwarf_shots_info = self._read_shotsinfo(Path(os.path.join(self.current_folder, "shotsInfo.json")))
         self._DARK_RE = re.compile(
             r"dark_exp_(?P<exp>[0-9]+\.?[0-9]*)_gain_(?P<gain>[0-9]+)_bin_(?P<bin>[0-9]+)_(?P<temp>[0-9]+)C",
             re.IGNORECASE,
@@ -2920,7 +2942,6 @@ class DwarfUtils:
             return 0
         return None
 
-
     def _pick_best_calib_subfolder(self, parent: Path, cam_name: str, ir_code: Optional[int], gain: int) -> Optional[Path]:
         """Pick best matching subfolder in CALI_FRAME/{bias|flat}."""
         if not parent.is_dir():
@@ -2973,7 +2994,7 @@ class DwarfUtils:
         return sorted(set(out))
 
     def _select_matching_darks(self, dark_dir: Path) -> List[Path]:
-        shots = self.dwarfShotsInfo
+        shots = self.dwarf_shots_info
         files = self._glob_fits(dark_dir)
         if not files:
             return []

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -25,6 +25,7 @@ The following subdirectories are optional:
 """
 CHANGELOG:
 
+2.1.0 - Improve DWARF experience using code from DeepSkyLab (find lights/dark/bias/flat files and filter thanks to shotsInfo.json)
 2.0.7 - Refactored directory selection for better maintainability
 2.0.6 - Ignore dot files from macs
       - Fix black frames check bug

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -600,7 +600,7 @@ class PreprocessingInterface(QMainWindow):
     def convert_files(self, dir_name):
         directory = os.path.join(self.current_working_directory, dir_name)
 
-        if not os.path.isdir(directory) and self.dwarf is not None and dir_name in ["biases", "flats"]:
+        if not os.path.isdir(directory) and self.dwarf is not None and dir_name in ["biases", "flats", "darks"]:
             self.siril.log(f"DWARF telescope: try to find {dir_name} into ../CALI_FRAME/", LogColor.BLUE)
             self.dwarf.copy_calibration_files(dir_name) #  If Dwarf, first let's try to fetch the correct calibration files
 
@@ -2915,16 +2915,32 @@ class DwarfManager:
 
     def copy_calibration_files(self, dir_name):
         parent = self.current_folder.parent / "CALI_FRAME"
-        root_paths = {
+
+        dwarf_cali_paths = {
             'biases': parent / "bias",
             'flats': parent / "flat",
-            'darks': parent / "dark"
+            'darks': parent / "dark" / self.cam
         }
 
-        best_directory = self._pick_best_calib_subfolder(root_paths[dir_name])
-        if best_directory is not None:
-            self.siril.log(f"Copy {best_directory.name} into {(self.current_folder / dir_name).name}", LogColor.GREEN)
-            shutil.copytree(best_directory, self.current_folder / dir_name)
+        if dir_name == "darks":
+            best_files = self._select_matching_darks(dwarf_cali_paths[dir_name])
+            if len(best_files) > 0:
+                self.siril.log(f"Copy {len(best_files)} dark file(s) into {(self.current_folder / dir_name).name}/", LogColor.GREEN)
+                os.makedirs(self.current_folder / dir_name, exist_ok=True)
+                for file in best_files:
+                    self.siril.log(f"Copy {file.absolute().name} into {(self.current_folder / dir_name).name}/", LogColor.GREEN)
+                    shutil.copy2(file, self.current_folder / dir_name)
+            else:
+                self.siril.log(f"Couldn't find matching darks", LogColor.SALMON)
+
+        elif dir_name in ["biases", "flats"]:
+            best_directory = self._pick_best_calib_subfolder(dwarf_cali_paths[dir_name])
+            if best_directory is not None:
+                self.siril.log(f"Copy {best_directory.absolute().name}/* into {(self.current_folder / dir_name).name}/", LogColor.GREEN)
+                shutil.copytree(best_directory, self.current_folder / dir_name)
+
+        else:
+            self.siril.log(f"Unknown calibration type {dir_name}", LogColor.RED)
 
     def _pick_best_calib_subfolder(self, parent: Path) -> Optional[Path]:
         """Pick best matching subfolder in CALI_FRAME/{bias|flat}."""

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -87,7 +87,6 @@ CHANGELOG:
 """
 
 import os
-from pathlib import Path
 import sys
 import math
 import shutil
@@ -97,6 +96,8 @@ from datetime import datetime
 import json
 from typing import Dict, List, Optional, Tuple
 import re
+from pathlib import Path
+from dataclasses import dataclass
 
 
 s.ensure_installed("PyQt6", "numpy", "astropy")
@@ -356,7 +357,20 @@ class PreprocessingInterface(QMainWindow):
                     f"Current working directory is invalid: {self.current_working_directory}, reprompting...",
                     LogColor.SALMON,
                 )
-                changed_cwd = False      
+                changed_cwd = False
+        elif os.path.exists(os.path.join(self.current_working_directory, "shotsInfo.json")):
+            msg = "You don't have 'lights' directory, but I've found a shotsinfo.json so you may be using a DWARF Telescope, do you want me to try to create the 'lights' directory for you and put your fits files in it?"
+            answer = QMessageBox.question(self, "Copy Dwarf fits into Lights Dir", msg)
+            if answer == QMessageBox.StandardButton.Yes:
+                dwarf = DwarfUtils(self.current_working_directory, self.siril)
+                dwarf.create_lights_folder()
+                changed_cwd = True
+            else:
+                self.siril.log(
+                    f"Current working directory is invalid: {self.current_working_directory}, reprompting...",
+                    LogColor.SALMON,
+                )
+                changed_cwd = False
 
         if not changed_cwd:
             while True:
@@ -411,6 +425,23 @@ class PreprocessingInterface(QMainWindow):
                             LogColor.GREEN,
                         )
                     break
+
+                elif os.path.exists(os.path.join(selected_dir, "shotsInfo.json")):
+                    msg = "You don't have 'lights' directory, but I've found a shotsinfo.json so you may be using a DWARF Telescope, do you want me to try to create the 'lights' directory for you and put your fits files in it?"
+                    answer = QMessageBox.question(self, "Copy Dwarf fits into Lights Dir", msg)
+                    if answer == QMessageBox.StandardButton.Yes:
+                        dwarf = DwarfUtils(selected_dir, self.siril)
+                        dwarf.create_lights_folder()                        
+                        self.siril.cmd("cd", f'"{selected_dir}"')
+                        os.chdir(selected_dir)
+                        self.current_working_directory = selected_dir
+                        self.cwd_label_text = f"Current working directory: {selected_dir}"
+                        self.siril.log(
+                            f"Updated current working directory to: {selected_dir}",
+                            LogColor.GREEN,
+                        )                        
+                    break
+
                 else:
                     msg = f"The selected directory must contain a subdirectory named 'lights'.\nYou selected: {selected_dir}. Please try again."
                     self.siril.log(msg, LogColor.SALMON)
@@ -2781,6 +2812,7 @@ class PreprocessingInterface(QMainWindow):
         except Exception as e:
             self.siril.log(f"Failed to load presets: {e}", LogColor.RED)
 
+@dataclass
 class DwarfShotsInfo:
     target: str
     exp_s: float
@@ -2797,7 +2829,8 @@ class DwarfShotsInfo:
         if self.min_temp is None or self.max_temp is None:
             return None
         return (self.min_temp + self.max_temp) / 2.0
-    
+
+@dataclass    
 class DwarfDarkMeta:
     exp_s: float
     gain: int
@@ -2808,13 +2841,26 @@ class DwarfUtils:
     # This class encapsulates code initially created by DeepSkyLab for his "DWARF Mini One‑Click Preprocess for Siril" script
     # https://youtu.be/GnNZ2issC-Y
 
-    def __init__(self, workdir: Path):
-        self.dwarfShotsInfo = self._read_DwarfShotsInfo(workdir)
+    def __init__(self, workdir: str, siril):
+        self.siril = siril
+        self.current_folder = Path(workdir)
+        self.dwarfShotsInfo = self._read_shotsinfo(Path(os.path.join(self.current_folder, "shotsInfo.json")))
         self._DARK_RE = re.compile(
             r"dark_exp_(?P<exp>[0-9]+\.?[0-9]*)_gain_(?P<gain>[0-9]+)_bin_(?P<bin>[0-9]+)_(?P<temp>[0-9]+)C",
             re.IGNORECASE,
         )        
         self._TEMP_SUFFIX_RE = re.compile(r".*_[+-]?\d+C\.(fit|fits|fts)$", re.IGNORECASE)
+
+    def _log(self, msg, color = LogColor.RED): 
+        self.siril.log(msg, color)
+
+    def create_lights_folder(self):
+        lights_directory = os.path.join(self.current_folder, "lights")
+        os.makedirs(lights_directory, exist_ok=True)        
+        (light_files, _, _) = self._select_light_files()
+        for light_file in light_files:
+            shutil.copy2(light_file, lights_directory)
+        self._log(f"{lights_directory} created, {len(light_files)} files copied in it", LogColor.GREEN)
 
     def _read_shotsinfo(self, shotsinfo_path: Path) -> DwarfShotsInfo:
         with shotsinfo_path.open("r", encoding="utf-8") as f:
@@ -2918,6 +2964,13 @@ class DwarfUtils:
         except Exception:
             return None
 
+    def _glob_fits(self, folder: Path) -> List[Path]:
+        exts = ("*.fit", "*.fits", "*.fts", "*.FIT", "*.FITS", "*.FTS")
+        out: List[Path] = []
+        for pat in exts:
+            out.extend(folder.glob(pat))
+        out = [p for p in out if p.is_file()]
+        return sorted(set(out))
 
     def _select_matching_darks(self, dark_dir: Path) -> List[Path]:
         shots = self.dwarfShotsInfo
@@ -2957,7 +3010,7 @@ class DwarfUtils:
         chosen = [f for (f, m) in candidates if abs(m.temp_c - target_t) == best_dist]
         return sorted(chosen)
 
-    def _fits_layer_count(path: Path) -> Optional[int]:
+    def _fits_layer_count(self, path: Path) -> Optional[int]:
         """Cheap FITS header peek to estimate # layers.
 
         - NAXIS<=2 -> 1 layer
@@ -3005,12 +3058,13 @@ class DwarfUtils:
         return naxis3
 
 
-    def _select_light_files(self, target_dir: Path) -> Tuple[List[Path], Dict[int, int], List[Path]]:
+    def _select_light_files(self) -> Tuple[List[Path], Dict[int, int], List[Path]]:
         """Return (selected_subs, layer_hist, excluded_fits).
 
         Excludes DWARF products like stacked*.fits and filters by majority layer count
         to prevent Siril sequence aborts.
         """
+        target_dir = self.current_folder
         allfits = self._glob_fits(target_dir)
 
         excluded: List[Path] = []

--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -353,6 +353,7 @@ class PreprocessingInterface(QMainWindow):
                 if self.check_directory(selected_dir):
                     break
 
+        self.load_dwarf(self.current_working_directory)
         self.create_widgets()
         # Initialize fits_files_count before creating widgets
         self.fits_files_count = 0


### PR DESCRIPTION
As discussed in #89 the script can be improved for DWARF users by automatically getting the correct Bias/Dark/Flat/Lights but also getting the correct filter.
Most of the work has already been done by DeepSkyLab in his "DWARF Mini One‑Click Preprocess for Siril" script, so let's try to incorporte it into this script.

To ensure we don't break anything the current folder usage won't be changed even for DWARF users, however if a folder is missing (lights/ or others), and we detect a `shotsInfo.json` file (DWARF metadata about the shot) we will propose the user to create the missing folder for him and copy/move his files from the usual DWARF location to the expected one.
We can also automatically set some values based on this metadata file: filter, geolocation.

Technically the external code will be encapsulated into a separate Python class (with some refactoring), and we will only add optional steps in the script to use it.