### PR TITLE
Add selective local astrometry.net fallback to OSC preprocessor

### DIFF
--- a/Naztronomy-OSC_PP.py
+++ b/Naztronomy-OSC_PP.py
@@ -497,6 +497,7 @@ class PreprocessingInterface(QMainWindow):
             return
 
         self.fits_extension = self.siril.get_siril_config("core", "extension")
+        self.astrometry_net_available = self.local_astrometry_net_available()
         # home directory is unchanged
         self.home_directory = self.siril.get_siril_wd()
         self.current_working_directory = self.siril.get_siril_wd()
@@ -1530,8 +1531,40 @@ class PreprocessingInterface(QMainWindow):
                 )
             )
 
+    def local_astrometry_net_available(self):
+        """Return True when Siril can find a local solve-field installation."""
+        configured_dir = ""
+        try:
+            configured_dir = self.siril.get_siril_config("core", "asnet_dir")
+        except (s.DataError, s.CommandError, s.SirilError):
+            pass
+
+        if configured_dir and configured_dir != "(not set)":
+            candidates = [
+                os.path.join(configured_dir, "solve-field"),
+                os.path.join(configured_dir, "solve-field.exe"),
+                os.path.join(configured_dir, "bin", "solve-field"),
+                os.path.join(configured_dir, "bin", "solve-field.exe"),
+            ]
+            if any(os.path.isfile(candidate) for candidate in candidates):
+                return True
+
+        if shutil.which("solve-field"):
+            return True
+
+        if sys.platform.startswith("win"):
+            ansvr_root = os.path.join(
+                os.environ.get("LOCALAPPDATA", ""), "cygwin_ansvr"
+            )
+            return any(
+                os.path.isfile(os.path.join(ansvr_root, "bin", executable))
+                for executable in ("solve-field", "solve-field.exe")
+            )
+
+        return False
+
     # Plate solve on sequence runs when file count < 2048
-    def seq_plate_solve(self, seq_name):
+    def seq_plate_solve(self, seq_name, use_astrometry_net=False):
         """Runs the siril command 'seqplatesolve' to plate solve the converted files."""
         # self.siril.cmd("cd", "process")
         args = ["seqplatesolve", seq_name]
@@ -1543,6 +1576,23 @@ class PreprocessingInterface(QMainWindow):
             self.siril.log(f"Platesolved {seq_name}", LogColor.GREEN)
             return True
         except (s.DataError, s.CommandError, s.SirilError) as e:
+            if use_astrometry_net and self.astrometry_net_available:
+                self.siril.log(
+                    f"Siril seqplatesolve reported a failure; retrying unsolved "
+                    f"frames with local astrometry.net (slower): {e}",
+                    LogColor.SALMON,
+                )
+                fallback_args = [arg for arg in args if arg != "-force"]
+                fallback_args.extend(["-localasnet", "-blindpos", "-blindres"])
+                try:
+                    self.siril.cmd(*fallback_args)
+                    self.siril.log(
+                        f"Astrometry.net fallback completed for {seq_name}",
+                        LogColor.GREEN,
+                    )
+                    return True
+                except (s.DataError, s.CommandError, s.SirilError) as fallback_error:
+                    e = fallback_error
             self.siril.log(
                 f"seqplatesolve failed, going to try regular registration: {e}",
                 LogColor.SALMON,
@@ -2338,6 +2388,17 @@ class PreprocessingInterface(QMainWindow):
         self.bg_extract_check.setToolTip(bg_extract_tooltip)
         preprocessing_layout.addWidget(self.bg_extract_check)
 
+        self.astrometry_net_check = QCheckBox(
+            "Fall back to local astrometry.net for unsolved frames (slower)"
+        )
+        self.astrometry_net_check.setToolTip(
+            "After Siril's built-in sequence solve reports a failure, retry only "
+            "frames without an existing astrometric solution using local "
+            "astrometry.net. Requires suitable astrometry.net index files."
+        )
+        if self.astrometry_net_available:
+            preprocessing_layout.addWidget(self.astrometry_net_check)
+
         drizzle_tooltip = "Drizzle integration can improve resolution but increases processing time and file size. Use values above 1.0 with caution."
         self.drizzle_checkbox = QCheckBox("Enable Drizzle")
         self.drizzle_checkbox.setToolTip(drizzle_tooltip)
@@ -2631,6 +2692,10 @@ class PreprocessingInterface(QMainWindow):
         process_btn.clicked.connect(
             lambda: self.run_script(
                 bg_extract=self.bg_extract_check.isChecked(),
+                use_astrometry_net=(
+                    self.astrometry_net_available
+                    and self.astrometry_net_check.isChecked()
+                ),
                 drizzle=self.drizzle_checkbox.isChecked(),
                 drizzle_amount=round(self.drizzle_amount_spinbox.value(), 1),
                 pixel_fraction=round(self.pixel_fraction_spinbox.value(), 2),
@@ -2819,6 +2884,10 @@ class PreprocessingInterface(QMainWindow):
         presets = {
             "dark_flats": self.dark_flats_check.isChecked(),
             "bg_extract": self.bg_extract_check.isChecked(),
+            "use_astrometry_net": (
+                self.astrometry_net_available
+                and self.astrometry_net_check.isChecked()
+            ),
             "drizzle": self.drizzle_checkbox.isChecked(),
             "drizzle_amount": round(self.drizzle_amount_spinbox.value(), 1),
             "pixel_fraction": round(self.pixel_fraction_spinbox.value(), 2),
@@ -2945,6 +3014,10 @@ class PreprocessingInterface(QMainWindow):
                 # Load UI settings
                 self.dark_flats_check.setChecked(presets.get("dark_flats", False))
                 self.bg_extract_check.setChecked(presets.get("bg_extract", False))
+                self.astrometry_net_check.setChecked(
+                    self.astrometry_net_available
+                    and presets.get("use_astrometry_net", False)
+                )
                 self.drizzle_checkbox.setChecked(presets.get("drizzle", False))
                 self.drizzle_amount_spinbox.setValue(presets.get("drizzle_amount", 1.0))
                 self.pixel_fraction_spinbox.setValue(presets.get("pixel_fraction", 1.0))
@@ -3053,6 +3126,7 @@ class PreprocessingInterface(QMainWindow):
     def run_script(
         self,
         bg_extract: bool = False,
+        use_astrometry_net: bool = False,
         drizzle: bool = False,
         drizzle_amount: float = UI_DEFAULTS["drizzle_amount"],
         pixel_fraction: float = UI_DEFAULTS["pixel_fraction"],
@@ -3100,6 +3174,7 @@ class PreprocessingInterface(QMainWindow):
             f"Running script version {VERSION} with arguments:\n"
             f"dark_flats={self.dark_flats_check.isChecked()}\n"
             f"bg_extract={bg_extract}\n"
+            f"use_astrometry_net={use_astrometry_net}\n"
             f"drizzle={drizzle}\n"
             f"drizzle_amount={drizzle_amount}\n"
             f"pixel_fraction={pixel_fraction}\n"
@@ -3299,7 +3374,8 @@ class PreprocessingInterface(QMainWindow):
                     individual_seq_name = "bkg_" + individual_seq_name
 
                 individual_plate_solve_status = self.seq_plate_solve(
-                    seq_name=individual_seq_name
+                    seq_name=individual_seq_name,
+                    use_astrometry_net=use_astrometry_net,
                 )
 
                 if individual_plate_solve_status:
@@ -3552,7 +3628,10 @@ class PreprocessingInterface(QMainWindow):
                 self.seq_bg_extract(seq_name=seq_name)
                 seq_name = "bkg_" + seq_name
 
-            plate_solve_status = self.seq_plate_solve(seq_name=seq_name)
+            plate_solve_status = self.seq_plate_solve(
+                seq_name=seq_name,
+                use_astrometry_net=use_astrometry_net,
+            )
 
             if plate_solve_status:
                 self.seq_apply_reg(
@@ -3693,7 +3772,10 @@ class PreprocessingInterface(QMainWindow):
                 self.siril.cmd("link", "lights")
                 seq_name = "lights_"
 
-                plate_solve_ok = self.seq_plate_solve(seq_name=seq_name)
+                plate_solve_ok = self.seq_plate_solve(
+                    seq_name=seq_name,
+                    use_astrometry_net=use_astrometry_net,
+                )
                 if plate_solve_ok:
                     try:
                         self.siril.cmd(
@@ -3829,7 +3911,10 @@ class PreprocessingInterface(QMainWindow):
                         LogColor.BLUE,
                     )
                     try:
-                        self.seq_plate_solve(seq_name=seq_name)
+                        self.seq_plate_solve(
+                            seq_name=seq_name,
+                            use_astrometry_net=use_astrometry_net,
+                        )
                         # self.siril.cmd(
                         #     "seqplatesolve",
                         #     seq_name,


### PR DESCRIPTION
## Summary

Adds an optional local astrometry.net fallback to the OSC preprocessor.

When enabled, the script now:

1. Runs Siril's built-in `seqplatesolve` normally with `-force`.
2. If that pass reports a failure, retries with `-localasnet -blindpos -blindres` and without `-force`, allowing Siril to skip frames that already have astrometric solutions.
3. If the retry also fails, continues to the existing global-registration fallback.

The option is disabled by default and is only displayed when a local `solve-field` installation can be detected through Siril's configured astrometry.net directory, `PATH`, or the standard Windows ansvr location. Preset persistence is also gated by availability.

This is the OSC half of the prototype discussed in #105 and supersedes the combined draft in #106.

## Why

Some smart-telescope frames fail Siril's built-in plate solver but solve successfully with a locally installed astrometry.net. Retrying without `-force` limits the slower fallback to frames that remain unsolved instead of re-solving the entire sequence.

The OSC preprocessor is the primary use case because it provides the required multi-session workflow.

## Validation

- Ran Python syntax parsing for the modified script.
- Ran mocked command-path tests confirming:
  - the built-in pass includes `-force`;
  - the astrometry.net retry omits `-force`;
  - the retry includes `-localasnet`, `-blindpos`, and `-blindres`;
  - a failed retry returns to the existing registration path.
- Tested locally on macOS with real image data and confirmed from Siril's command output that the built-in pass ran with `-force`, followed by the local astrometry.net retry without `-force`.

## AI disclosure

Parts of this implementation were drafted with OpenAI Codex assistance and were reviewed, modified, and locally tested before submission.
