### PR TITLE
Fix for #112

### DIFF
--- a/Naztronomy-Smart_Telescope_PP.py
+++ b/Naztronomy-Smart_Telescope_PP.py
@@ -557,6 +557,10 @@ class PreprocessingInterface(QMainWindow):
                     hdr.set("YPIXSZ", 2.9)  # add a YPIXSZ header
                     telescope = "Odyssey"
 
+                # needed by siril to set properly the pixel size of the stacked image
+                hdr.set("XBINNING", 1) # add a XBINNING header
+                hdr.set("YBINNING", 1) # add a YBINNING header
+
                 if hdr["SOFTVER"].startswith("4.2") and telescope.startswith(
                     "eVscope"
                 ):  # fix for bayer issue with latest FW 4.2


### PR DESCRIPTION
Fix for #112
Tested and confirmed by the bug originator with Unistellar Odyssey date and by myself with an Unistellar eVscope1. This fix allows the batch mode to work properly with Unistellar scopes data and also fix the pixel size of the final stacked image in normal non batch mode.